### PR TITLE
chore(docker): update URLs after migration

### DIFF
--- a/content/technical-guide/installation/_index.md
+++ b/content/technical-guide/installation/_index.md
@@ -26,7 +26,7 @@ Cawemo consists of several components that are tied together with [Docker Compos
 
 ## 1. Log-in to Camunda Docker Registry
 
-The Cawemo Docker images are hosted on our dedicated Docker registry and are available to enterprise customers only. You can browse the available images in our [Docker registry](https://repository.camunda.cloud/#browse/search/docker) after logging-in with your credentials.
+The Cawemo Docker images are hosted on our dedicated Docker registry and are available to enterprise customers only. You can browse the available images in our [Docker registry](https://registry.camunda.cloud) after logging-in with your credentials.
 
 Make sure to log-in correctly:
 

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 
 services:
   apiserver:
-    image: registry.camunda.cloud/cawemo-apiserver:1.1.1
+    image: registry.camunda.cloud/cawemo-ee/cawemo-apiserver:1.1.1
     container_name: cawemo-apiserver
     restart: always
     labels:
@@ -44,7 +44,7 @@ services:
     command: classpath:///apiserver-enterprise.toml
 
   webapp:
-    image: registry.camunda.cloud/cawemo-webapp:1.1.1
+    image: registry.camunda.cloud/cawemo-ee/cawemo-webapp:1.1.1
     container_name: cawemo-webapp
     restart: always
     labels:
@@ -76,7 +76,7 @@ services:
       - garufa:garufa
 
   garufa:
-    image: registry.camunda.cloud/cawemo-garufa:1.1.1
+    image: registry.camunda.cloud/cawemo-ee/cawemo-garufa:1.1.1
     container_name: cawemo-garufa
     restart: always
     labels:


### PR DESCRIPTION
- old URLs will continue to work for existing customers for the time being
- customers should adopt new URLs whenever possible

**This change should be backported to all branches.**

Related to INFRA-1092