### PR TITLE
fix(docs): set baseURL to '/cawemo/1.4/'

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-baseURL: '/cawemo/develop/'
+baseURL: '/cawemo/1.4/'
 languageCode: 'en-us'
 title: 'Cawemo'
 theme: 'camunda'


### PR DESCRIPTION
Currently, all links in our `1.4` documentation are pointing to develop (see https://docs.camunda.org/cawemo/1.4/) due to the wrong definition of `baseURL`.