### PR TITLE
fix(layout): fix layout issues related to older hugo version

### DIFF
--- a/content/technical-guide/installation/_index.md
+++ b/content/technical-guide/installation/_index.md
@@ -57,11 +57,13 @@ In the same server directory, create an `.env` file with the following content a
 
 {{< note title="Generating unique secrets" class="info" >}}
 The below configuration lacks values for:
-* `SERVER_SESSION_COOKIE_SECRET`
-* `WEBSOCKET_SECRET`
-* `CLIENT_SECRET`
-* `IAM_DATABASE_ENCRYPTION_KEY`
-* `IAM_TOKEN_SIGNING_KEY`
+<ul>
+<li>`SERVER_SESSION_COOKIE_SECRET`</li>
+<li>`WEBSOCKET_SECRET`</li>
+<li>`CLIENT_SECRET`</li>
+<li>`IAM_DATABASE_ENCRYPTION_KEY`</li>
+<li>`IAM_TOKEN_SIGNING_KEY`</li>
+</ul>
 
 Please generate unique sequences of 32 random characters with a tool of your choice for all the secrets and the database encryption key.
 

--- a/content/technical-guide/installation/update.md
+++ b/content/technical-guide/installation/update.md
@@ -12,7 +12,7 @@ Roughly every quarter of a year a new minor version of Cawemo is released. This 
 
 {{< note title="Updating from an older version of Cawemo?" class="warning" >}} If you are still using an older version of Cawemo
 (version < 1.4) and want to upgrade to version 1.5, please follow
-[the steps described at the end of this page](#migrate-from-an-older-version-to-15).{{< /note >}}
+[the steps described at the end of this page](#migrate-from-an-older-version-to-1-5).{{< /note >}}
 
 # Migrate from version 1.4 to 1.5
 
@@ -25,14 +25,15 @@ migrated from Cawemo to Camunda Account. Cawemo 1.5 will then use Camunda Accoun
    by working through steps **1 to 4** of the [installation instructions]({{< ref "_index.md" >}}). **Make sure that
    you do _not_ start Cawemo yet.**
 1. Start the Camunda Account `backend` service _only_ with:
-   ```
-   docker-compose up -d backend
-   ```
+
+    ```
+    docker-compose up -d backend
+    ```
 1. Make sure that the Camunda Account backend has started successfully by checking that
    ```
    docker-compose ps backend
    ```
-   returns `Up (healthy)` in the `State` column. This is based on the health check and takes around 30 seconds. 
+   returns `Up (healthy)` in the `State` column. This is based on the health check and takes around 30 seconds.
 1. Migrate the users from the Cawemo database to Camunda Account [as described below](#migrate-user-data-from-cawemo-to-camunda-account).
 1. Once the user migration has been finished, start all other services (see [step 5]({{< ref "_index.md#5-run-cawemo" >}})) with:
    ```
@@ -63,11 +64,11 @@ data migration completed successfully
 ```
 # Migrate from an older version to 1.5
 If you are still using an older version of Cawemo (< 1.4), you need to **migrate to version 1.4 first** before you can
-[migrate to version 1.5](#migrate-from-version-14-to-15):
+[migrate to version 1.5](#migrate-from-version-1-4-to-1-5):
 
 1. Stop Cawemo
 1. Make a database backup
 1. Update your [docker-compose.yml](https://docs.camunda.org/cawemo/1.4/docker-compose.yml) and `.env` file
    according to the [installation instructions for version 1.4.](https://docs.camunda.org/cawemo/1.4/technical-guide/installation)
 1. Start Cawemo again
-1. Proceed with the [steps listed above](#migrate-from-version-14-to-15)
+1. Proceed with the [steps listed above](#migrate-from-version-1-4-to-1-5)


### PR DESCRIPTION
Fixes the following layout glitches that did not exist in a newer `hugo` version I was using when I updated the documentation.

#### List not correctly rendered within note:
<img width="570" alt="grafik" src="https://user-images.githubusercontent.com/8794084/104019228-78104b00-51bb-11eb-82df-064d305dda7e.png">
should look like this:

<img width="335" alt="grafik" src="https://user-images.githubusercontent.com/8794084/104019376-bc035000-51bb-11eb-88e6-50c1cc966f67.png">

#### Code blocks not rendered within list:
<img width="717" alt="grafik" src="https://user-images.githubusercontent.com/8794084/104019301-970edd00-51bb-11eb-9f4e-9f832d97d5a0.png">
should look like this:

<img width="737" alt="grafik" src="https://user-images.githubusercontent.com/8794084/104019426-d5a49780-51bb-11eb-8619-e1c0969a69b5.png">

#### Anchor links
 Anchor link resolves to `#migrate-from-version-1-4-to-1-5` instead of `#migrate-from-version-14-to-15`