### PR TITLE
chore(docs): improve LDAP server URL example

### DIFF
--- a/content/technical-guide/installation/ldap-support.md
+++ b/content/technical-guide/installation/ldap-support.md
@@ -25,7 +25,7 @@ In order to activate the LDAP integration, you must configure the required of th
  </tr>
   <tr>
     <td>IAM_LDAP_SERVER_URL</td>
-    <td>ldaps://ldap.camunda.com/</td>
+    <td>ldaps://ldap.example.com/</td>
     <td>URL at which the LDAP server can be reached</td>
     <td>Required</td>
     <td>Required</td>


### PR DESCRIPTION
As suggested by @cmur2 on [Slack](https://camunda.slack.com/archives/C01B2SF0DKM/p1616496529003800?thread_ts=1616435923.000500&cid=C01B2SF0DKM), I changed the example LDAP server domain from `camunda` to `example` in order to avoid customers causing an increased load on our systems by accidentally using the example URL.

cc @wollefitz 