### PR TITLE
chore(docs): add reverse proxy configuration

### DIFF
--- a/content/technical-guide/installation/_index.md
+++ b/content/technical-guide/installation/_index.md
@@ -86,13 +86,16 @@ For more details on how to configure the LDAP integration of Camunda Account, pl
 To let users access Cawemo via their web browsers there are a couple of requirements that the system administrator has to fulfill usually using some kind of reverse proxy server.
 
 * The `SERVER_URL` and `IAM_BASE_URL` specified in the `.env` file must be accessible by the user's web browser via HTTPS with certificate validation.
-  * The configuration above enforces the use of HTTPS. You can change this by setting `SERVER_HTTPS_ONLY=false` which is **not** recommended for production use though.
+  * The configuration above enforces the use of HTTPS.
+    You can change this by setting `SERVER_HTTPS_ONLY=false`, but we do **not** recommend doing this in a production environment.
 * The traffic for Cawemo has to be proxied to port `8080` on the host running the Docker containers.
 * The traffic for Camunda Account has to be proxied to port `8090` on the host running the Docker containers.
 * The domain configured for Camunda Account must have a DNS resolution configured to be accessible to the web browser and the Cawemo backend (Docker container).
 * In addition to that the reverse proxy must support websockets and allow the user's web browser to connect to the `BROWSER_WEBSOCKET_HOST` and `BROWSER_WEBSOCKET_PORT` depending on the setting of `BROWSER_WEBSOCKET_FORCETLS` with TLS and certificate validation enabled. This traffic has to be proxied to port `8060` on the host running the Cawemo Docker containers.
 
 Please also ensure that Cawemo and Camunda Account can correctly access other services like the PostgreSQL database and the SMTP server.
+
+For an example on how to configure Cawemo using a reverse proxy server with SSL support please refer to [Reverse Proxy Configuration]({{< ref "reverse-proxy-configuration.md" >}}).
 
 ## 5. Run Cawemo
 

--- a/content/technical-guide/installation/reverse-proxy-configuration.md
+++ b/content/technical-guide/installation/reverse-proxy-configuration.md
@@ -1,0 +1,45 @@
+---
+title: 'Reverse Proxy Configuration'
+weight: 70
+
+menu:
+  main:
+    identifier: 'reverse-proxy-configuration'
+    parent: 'installation'
+---
+
+This page offers a sample configuration of how to run Cawemo with a pre-configured reverse proxy server with SSL support using NGINX.
+To do so, please follow the following steps:
+
+## 1. Download `docker-compose.reverse-proxy.yml`
+
+Download this [docker-compose.reverse-proxy.yml]({{< refstatic "docker-compose.reverse-proxy.yml" >}}) file to the same location you put the `docker-compose.yml` [from step 2 of the on-premise installation]({{< ref "_index.md#2-download-docker-composeyml-file">}}).
+
+## 2. Extend the `.env` File
+
+Add these values to the `.env` file you created [in step 3 of the on-premise installation]({{< ref "_index.md#3-create-an-env-file">}}) and adjust the values according to your own setup.
+
+```
+IAM_SERVER_HOST=iam.example.com
+SERVER_TLS_CERTIFICATES_PATH=/path/to/certificates
+```
+
+## 3. Create a Folder For Your Certificates
+
+You have to provide SSL certificates for the host names used in `SERVER_HOST`, `BROWSER_WEBSOCKET_HOST` and `IAM_SERVER_HOST` via the path configured in `SERVER_TLS_CERTIFICATES_PATH`.
+The certificates must be named after a certain scheme:
+
+* For individual certificates use _my.domain.tld.{key,crt,pem}_.
+* For certificate bundles use anything other than the above, e.g. _domain.tld.{crt,key,pem}_.
+
+Beware that self-signed certificates won't work.
+
+## 4. Run Cawemo
+
+Use the following command for running Cawemo with the provided reverse proxy:
+
+```
+docker-compose -f docker-compose.yml -f docker-compose.reverse-proxy.yml up -d
+```
+
+Point your web browser to the URL you defined above as `SERVER_URL` to verify that the application is running.

--- a/input/.env.cawemo
+++ b/input/.env.cawemo
@@ -2,15 +2,15 @@
 # CAWEMO #
 ##########
 # Please use the domain root for Cawemo's SERVER_URL
-SERVER_URL=https://cawemo.your-company.com
-SERVER_HOST=cawemo.your-company.com
+SERVER_URL=https://cawemo.example.com
+SERVER_HOST=cawemo.example.com
 SERVER_HTTPS_ONLY=true
 SERVER_SESSION_COOKIE_SECRET=
 
 ############
 # DATABASE #
 ############
-DB_HOST=postgresql.your-company.com
+DB_HOST=postgresql.example.com
 DB_PORT=5432
 DB_NAME=cawemo
 DB_USER=cawemo
@@ -19,18 +19,18 @@ DB_PASSWORD=top-secret-123
 #########
 # EMAIL #
 #########
-SMTP_HOST=mail.your-company.com
+SMTP_HOST=mail.example.com
 SMTP_PORT=587
 SMTP_USER=cawemo
 SMTP_PASSWORD=top-secret-123
 SMTP_ENABLE_TLS=true
-SMTP_FROM_ADDRESS=cawemo@your-company.com
+SMTP_FROM_ADDRESS=cawemo@example.com
 SMTP_FROM_NAME=Cawemo
 
 ##############
 # WEBSOCKETS #
 ##############
-BROWSER_WEBSOCKET_HOST=cawemo.your-company.com
+BROWSER_WEBSOCKET_HOST=ws.example.com
 BROWSER_WEBSOCKET_PORT=8060
 BROWSER_WEBSOCKET_FORCETLS=true
 WEBSOCKET_SECRET=

--- a/static/.env
+++ b/static/.env
@@ -2,15 +2,15 @@
 # CAWEMO #
 ##########
 # Please use the domain root for Cawemo's SERVER_URL
-SERVER_URL=https://cawemo.your-company.com
-SERVER_HOST=cawemo.your-company.com
+SERVER_URL=https://cawemo.example.com
+SERVER_HOST=cawemo.example.com
 SERVER_HTTPS_ONLY=true
 SERVER_SESSION_COOKIE_SECRET=
 
 ############
 # DATABASE #
 ############
-DB_HOST=postgresql.your-company.com
+DB_HOST=postgresql.example.com
 DB_PORT=5432
 DB_NAME=cawemo
 DB_USER=cawemo
@@ -19,18 +19,18 @@ DB_PASSWORD=top-secret-123
 #########
 # EMAIL #
 #########
-SMTP_HOST=mail.your-company.com
+SMTP_HOST=mail.example.com
 SMTP_PORT=587
 SMTP_USER=cawemo
 SMTP_PASSWORD=top-secret-123
 SMTP_ENABLE_TLS=true
-SMTP_FROM_ADDRESS=cawemo@your-company.com
+SMTP_FROM_ADDRESS=cawemo@example.com
 SMTP_FROM_NAME=Cawemo
 
 ##############
 # WEBSOCKETS #
 ##############
-BROWSER_WEBSOCKET_HOST=cawemo.your-company.com
+BROWSER_WEBSOCKET_HOST=ws.example.com
 BROWSER_WEBSOCKET_PORT=8060
 BROWSER_WEBSOCKET_FORCETLS=true
 WEBSOCKET_SECRET=

--- a/static/docker-compose.reverse-proxy.yml
+++ b/static/docker-compose.reverse-proxy.yml
@@ -1,0 +1,27 @@
+version: '3.6'
+services:
+  reverse-proxy:
+    image: jwilder/nginx-proxy:alpine
+    volumes:
+      - "/var/run/docker.sock:/tmp/docker.sock:ro"
+      - "${SERVER_TLS_CERTIFICATES_PATH}:/etc/nginx/certs:ro"
+    ports: ["0.0.0.0:443:443"]
+    healthcheck:
+      test: "echo Running"
+      interval: 10s
+    environment:
+      HTTPS_METHOD: nohttp
+  webapp:
+    environment:
+      SERVER_HTTPS_ONLY: "true"
+      VIRTUAL_HOST: $SERVER_HOST
+      VIRTUAL_PORT: 8070
+  garufa:
+    environment:
+      VIRTUAL_HOST: $BROWSER_WEBSOCKET_HOST
+  backend:
+    environment:
+      ENFORCE_HTTPS: "true"
+  router:
+    environment:
+      VIRTUAL_HOST: $IAM_SERVER_HOST


### PR DESCRIPTION
Part of https://github.com/camunda/cawemo/issues/7322

This adds `jwilder/nginx-proxy:alpine` to our `docker-compose.yml`. It is excluded from starting when running `docker-compose up -d`, `docker-compose --profile reverse-proxy up -d` has to be called instead. The motivation behind this solution is to avoid having two separate `docker-compose.yml` in our documentation which might confuse customers.

Two new environment variables were introduced to `.env` for this to work:
* `SERVER_TLS_CERTIFICATES_PATH`
* `IAM_SERVER_HOST`

@CatalinaMoisuc @jfriedenstab Could you have a look if you like this approach? Is the documentation clear enough?