### PR TITLE
fix(docker-compose): fix user update endpoint URL for IAM backend

### DIFF
--- a/input/docker-compose.iam.yml
+++ b/input/docker-compose.iam.yml
@@ -38,7 +38,7 @@ services:
       LDAP_UUID_ATTRIBUTE: $IAM_LDAP_UUID_ATTRIBUTE
       LDAP_USER_NAME_ATTRIBUTES: $IAM_LDAP_USER_NAME_ATTRIBUTES
       LDAP_USER_EMAIL_ATTRIBUTE: $IAM_LDAP_USER_EMAIL_ATTRIBUTE
-      DEFAULT_CLIENT_USER_UPDATE_ENDPOINT: http://restapi/api/users
+      DEFAULT_CLIENT_USER_UPDATE_ENDPOINT: http://webapp:8070/api/users
     healthcheck:
       test: wget http://localhost:8081/actuator/health -q -O - > /dev/null 2>&1
       interval: 30s

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       LDAP_UUID_ATTRIBUTE: $IAM_LDAP_UUID_ATTRIBUTE
       LDAP_USER_NAME_ATTRIBUTES: $IAM_LDAP_USER_NAME_ATTRIBUTES
       LDAP_USER_EMAIL_ATTRIBUTE: $IAM_LDAP_USER_EMAIL_ATTRIBUTE
-      DEFAULT_CLIENT_USER_UPDATE_ENDPOINT: http://restapi/api/users
+      DEFAULT_CLIENT_USER_UPDATE_ENDPOINT: http://webapp:8070/api/users
     healthcheck:
       test: wget http://localhost:8081/actuator/health -q -O - > /dev/null 2>&1
       interval: 30s


### PR DESCRIPTION
IAM needs to call the `webapp` instead of the `restapi`.

@casulond: I checked your repo but it looks like `DEFAULT_CLIENT_USER_UPDATE_ENDPOINT` is not used in one of your `docker-compose.yml` files. So I guess it's sufficient to apply the fix only in here?