### PR TITLE
chore(docs): update IAM version to latest patch

### DIFF
--- a/content/technical-guide/installation/_index.md
+++ b/content/technical-guide/installation/_index.md
@@ -68,7 +68,7 @@ We provide a tool for generating a 4096 bit JWK:
 
 ```
 docker run --rm -t \
-  registry.camunda.cloud/iam-ee/iam-utility:v1.1.4 \
+  registry.camunda.cloud/iam-ee/iam-utility:v1.1.5 \
   yarn run generate-jwk
 ```
 

--- a/input/docker-compose.iam.yml
+++ b/input/docker-compose.iam.yml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
   backend:
-    image: registry.camunda.cloud/iam-ee/iam-backend:v1.1.4
+    image: registry.camunda.cloud/iam-ee/iam-backend:v1.1.5
     container_name: iam-backend
     environment:
       BACKEND_URL: $IAM_BASE_URL/api
@@ -44,7 +44,7 @@ services:
       timeout: 15s
       retries: 5
   frontend:
-    image: registry.camunda.cloud/iam-ee/iam-frontend:v1.1.4
+    image: registry.camunda.cloud/iam-ee/iam-frontend:v1.1.5
     container_name: iam-frontend
     depends_on:
       - backend
@@ -60,7 +60,7 @@ services:
       timeout: 15s
       retries: 5
   router:
-    image: registry.camunda.cloud/iam-ee/iam-router:v1.1.4
+    image: registry.camunda.cloud/iam-ee/iam-router:v1.1.5
     container_name: iam-router
     depends_on:
       - backend

--- a/static/docker-compose.yml
+++ b/static/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     ports:
       - '8060:8060'
   backend:
-    image: registry.camunda.cloud/iam-ee/iam-backend:v1.1.4
+    image: registry.camunda.cloud/iam-ee/iam-backend:v1.1.5
     container_name: iam-backend
     environment:
       BACKEND_URL: $IAM_BASE_URL/api
@@ -136,7 +136,7 @@ services:
       timeout: 15s
       retries: 5
   frontend:
-    image: registry.camunda.cloud/iam-ee/iam-frontend:v1.1.4
+    image: registry.camunda.cloud/iam-ee/iam-frontend:v1.1.5
     container_name: iam-frontend
     depends_on:
       - backend
@@ -152,7 +152,7 @@ services:
       timeout: 15s
       retries: 5
   router:
-    image: registry.camunda.cloud/iam-ee/iam-router:v1.1.4
+    image: registry.camunda.cloud/iam-ee/iam-router:v1.1.5
     container_name: iam-router
     depends_on:
       - backend


### PR DESCRIPTION
We recently released a security patch for IAM https://github.com/camunda/iam/releases/tag/v1.1.5 - this PR updates the IAM component versions in the docker yaml files.

There are no library updates with this patch because no dependencies were changed.