### PR TITLE
chore(docs): add Artifactory browse link as alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The Architecture Overview Diagram was created with [diagrams.net][diagrams.net] 
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/3.0/80x15.png"></a> The content on this site is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>.
 
 [c4 model]: https://c4model.com/
-[camunda nexus]: https://app.camunda.com/nexus/content/repositories/public/hugo/
+[camunda nexus]: https://app.camunda.com/nexus/service/rest/repository/browse/thirdparty/hugo/
 [diagrams.net]: https://diagrams.net
 [hugo]: http://gohugo.io/
 [title converter]: http://individed.com/code/to-title-case/

--- a/content/technical-guide/integrations/engine.md
+++ b/content/technical-guide/integrations/engine.md
@@ -37,7 +37,8 @@ The simplest way to install this plugin is by adding a dependency to your pom.xm
 Alternatively, you can also add the JAR to your classpath. To get the JAR, you should:
 
 1. Go to [Camunda Nexus](https://app.camunda.com/nexus) and login with your credentials.
-2. Go to [Browse/camunda-bpm-ee/org/camunda-bpm/cawemo-engine-plugin](https://app.camunda.com/nexus/#browse/browse:camunda-bpm-ee:org%2Fcamunda%2Fbpm%2Fcawemo-engine-plugin%2F{{< integrationVersion >}}%2Fcawemo-engine-plugin-{{< integrationVersion >}}.jar)
+2. Go to [(Deprecated)Browse/camunda-bpm-ee/org/camunda-bpm/cawemo-engine-plugin](https://app.camunda.com/nexus/#browse/browse:camunda-bpm-ee:org%2Fcamunda%2Fbpm%2Fcawemo-engine-plugin%2F{{< integrationVersion >}}%2Fcawemo-engine-plugin-{{< integrationVersion >}}.jar)
+Go to [Browse/camunda-bpm-ee/org/camunda-bpm/cawemo-engine-plugin](https://camunda.jfrog.io/ui/repos/tree/General/camunda-bpm-ee%2Forg%2Fcamunda%2Fbpm%2Fcawemo-engine-plugin%2F{{< integrationVersion >}}%2Fcawemo-engine-plugin-{{< integrationVersion >}}.jar)
 3. Download `cawemo-engine-plugin-{{< integrationVersion >}}.jar`
 
 {{<img src="../nexus-repo.png">}}


### PR DESCRIPTION
related to INFRA-2719

added the alternative link for artifactory browse, which would be the equivalent to Nexus.
The Nexus URL can't be redirected due to the usage of the client-side fragment identifier.

The docs also reference a direct link for Nexus, which would work with the Nexus redirect.