### PR TITLE
chore: document endpoints for files and projects

### DIFF
--- a/content/reference/rest-api/catalogs/_index.md
+++ b/content/reference/rest-api/catalogs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Catalog Projects'
-weight: 20
+weight: 40
 
 menu:
   main:

--- a/content/reference/rest-api/engine-projects/_index.md
+++ b/content/reference/rest-api/engine-projects/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Engine Projects'
-weight: 40
+weight: 60
 
 menu:
   main:

--- a/content/reference/rest-api/files/_index.md
+++ b/content/reference/rest-api/files/_index.md
@@ -1,0 +1,121 @@
+---
+title: 'Files'
+weight: 30
+
+menu:
+  main:
+    identifier: 'rest-api-files'
+    parent: 'rest-api'
+---
+
+See the list of all available [HTTP methods](#methods) for this resource at end of this page.
+
+# Resource Representation
+
+```json
+{
+  "canonicalPath": [
+    {
+      "id": "ccf4c1b7-4f36-4282-8beb-b66823285797",
+      "name": "My Folder"
+    }
+  ],
+  "created": "2019-12-15T23:45:32.000Z",
+  "createdBy": {
+    "id": "4975a794-26b0-47a9-b953-a57bb2dc5719",
+    "name": "foo"
+  },
+  "folderId": "c7385b2e-14ac-42b5-98fc-3c960201134c",
+  "id": "def751d7-eccd-4f94-952e-f62988cef786",
+  "name": "My First File",
+  "projectId": "6e1b3175-3b6c-4fc4-9af5-36081d6428c0",
+  "revision": 1,
+  "type": "BPMN",
+  "simplePath": "My Folder/My First File.bpmn",
+  "updated": "2020-12-15T23:45:32.000Z",
+  "updatedBy": {
+    "id": "c8bc0a6a-13bb-49ad-9fcd-60a9a0c4b411",
+    "name": "bar"
+  }
+}
+```
+
+<table class="table table-striped">
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>canonicalPath</td>
+    <td>object[]</td>
+    <td>Contains the unique path of the file within the project. It is an array of objects representing folders which contain the id and the name of each path element.</td>
+  </tr>
+  <tr>
+    <td>created</td>
+    <td>date (in ISO-8601 format)</td>
+    <td>Creation date and time of the file.</td>
+  </tr>
+  <tr>
+    <td>createdBy.id</td>
+    <td>string</td>
+    <td>Unique identifier of the user who created the file.</td>
+  </tr>
+  <tr>
+    <td>createdBy.name</td>
+    <td>string</td>
+    <td>Name of the user who created the file.</td>
+  </tr>
+  <tr>
+    <td>folderId (optional)</td>
+    <td>string</td>
+    <td>Unique identifier of the parent folder the file is located in.</td>
+  </tr>
+  <tr>
+    <td>id</td>
+    <td>string</td>
+    <td>Unique identifier of the file.</td>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>string</td>
+    <td>Name of the file.</td>
+  </tr>
+  <tr>
+    <td>projectId</td>
+    <td>string</td>
+    <td>Unique identifier of the project the file is located in.</td>
+  </tr>
+  <tr>
+    <td>simplePath</td>
+    <td>string</td>
+    <td>Contains the human-readable path of the file within the project.</td>
+  </tr>
+  <tr>
+    <td>revision</td>
+    <td>number</td>
+    <td>Revision of the file.</td>
+  </tr>
+  <tr>
+    <td>type</td>
+    <td>number</td>
+    <td>Type of the file.<br/>Possible values: <i>BPMN</i>, <i>DMN</i>, <i>TEMPLATE_GENERIC</i>, or <i>TEMPLATE_SERVICE_TASK</i>.</td>
+  </tr>
+  <tr>
+    <td>updated</td>
+    <td>date (in ISO-8601 format)</td>
+    <td>Date and time when the file was last updated.</td>
+  </tr>
+  <tr>
+    <td>updatedBy.id</td>
+    <td>string</td>
+    <td>Unique identifier of the user who last updated the file.</td>
+  </tr>
+  <tr>
+    <td>updatedBy.name</td>
+    <td>string</td>
+    <td>Name of the user who last updated the file.</td>
+  </tr>
+</table>
+
+# Methods

--- a/content/reference/rest-api/files/get.md
+++ b/content/reference/rest-api/files/get.md
@@ -1,0 +1,62 @@
+---
+title: 'Files: get'
+weight: 10
+
+menu:
+  main:
+    name: 'get'
+    identifier: 'rest-api-files-get'
+    parent: 'rest-api-files'
+    pre: 'Gets a file by ID.'
+---
+
+Gets the latest version of a file by ID.
+
+# Request
+
+## HTTP Request
+
+```
+GET https://cawemo.com/api/v1/files/:id
+```
+
+## Path Parameters
+
+<table class="table table-striped">
+ <tr>
+   <th>Name</th>
+   <th>Type</th>
+   <th>Description</th>
+ </tr>
+  <tr>
+    <td>id</td>
+    <td>string</td>
+    <td>Unique identifier of the file to request.</td>
+  </tr>
+</table>
+
+## Request Body
+
+Do not supply a request body with this method.
+
+# Response
+
+If successful, this method returns the following response body:
+
+<table class="table table-striped">
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>content</td>
+    <td>string</td>
+    <td>Content of the requested file.</td>
+  </tr>
+  <tr>
+    <td>metadata</td>
+    <td>object</td>
+    <td>Metadata of the file, see <a href="{{< ref "/reference/rest-api/files/_index.md#resource-representation" >}}">File resource</a>.</td>
+  </tr>
+</table>

--- a/content/reference/rest-api/files/list.md
+++ b/content/reference/rest-api/files/list.md
@@ -1,0 +1,44 @@
+---
+title: 'Files: list'
+weight: 10
+
+menu:
+  main:
+    name: 'list'
+    identifier: 'rest-api-files-list'
+    parent: 'rest-api-files'
+    pre: 'Lists files.'
+---
+
+Lists all files within a project.
+
+# Request
+
+## HTTP Request
+
+```
+GET https://cawemo.com/api/v1/projects/:id/files
+```
+
+## Path Parameters
+
+<table class="table table-striped">
+ <tr>
+   <th>Name</th>
+   <th>Type</th>
+   <th>Description</th>
+ </tr>
+  <tr>
+    <td>id</td>
+    <td>string</td>
+    <td>Unique identifier of the project of which to list the files.</td>
+  </tr>
+</table>
+
+## Request Body
+
+Do not supply a request body with this method.
+
+# Response
+
+If successful, this method returns an array of [File resources]({{< ref "/reference/rest-api/files/_index.md#resource-representation" >}}) in the response body.

--- a/content/reference/rest-api/process-definitions/_index.md
+++ b/content/reference/rest-api/process-definitions/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Process Definitions'
-weight: 50
+weight: 70
 
 menu:
   main:
@@ -17,7 +17,7 @@ See the list of all available [HTTP methods](#methods) for this resource at end 
   "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<bpmn:definitions xmlns:bpmn=\"http://www.omg.org/spec/BPMN/20100524/MODEL\" xmlns:bpmndi=\"http://www.omg.org/spec/BPMN/20100524/DI\" xmlns:dc=\"http://www.omg.org/spec/DD/20100524/DC\" id=\"Definitions_1\" targetNamespace=\"http://bpmn.io/schema/bpmn\" xmlns:camunda=\"http://camunda.org/schema/1.0/bpmn\" camunda:diagramRelationId=\"7481b562-5fc4-498c-8735-514740576936\">\n  <bpmn:process id=\"Process_3ef3f8f4-0956-488c-930e-e61e1ab3d3f5\" isExecutable=\"true\">\n    <bpmn:startEvent id=\"StartEvent_1\" />\n  </bpmn:process>\n  <bpmndi:BPMNDiagram id=\"BPMNDiagram_1\">\n    <bpmndi:BPMNPlane id=\"BPMNPlane_1\" bpmnElement=\"Process_1\">\n      <bpmndi:BPMNShape id=\"_BPMNShape_StartEvent_2\" bpmnElement=\"StartEvent_1\">\n        <dc:Bounds x=\"150\" y=\"100\" width=\"36\" height=\"36\" />\n      </bpmndi:BPMNShape>\n    </bpmndi:BPMNPlane>\n  </bpmndi:BPMNDiagram>\n</bpmn:definitions>\n",
   "created": 1576453532000,
   "key": "def751d7-eccd-4f94-952e-f62988cef786",
-  "name": "My First process definition",
+  "name": "My First Process Definition",
   "updated": 1608075932000,
   "version": 1
 }

--- a/content/reference/rest-api/projects/_index.md
+++ b/content/reference/rest-api/projects/_index.md
@@ -1,0 +1,86 @@
+---
+title: 'Projects'
+weight: 20
+
+menu:
+  main:
+    identifier: 'rest-api-projects'
+    parent: 'rest-api'
+---
+
+See the list of all available [HTTP methods](#methods) for this resource at end of this page.
+
+# Resource Representation
+
+```json
+{
+  "created": "2019-12-15T23:45:32.000Z",
+  "createdBy": {
+    "id": "4975a794-26b0-47a9-b953-a57bb2dc5719",
+    "name": "foo"
+  },
+  "id": "def751d7-eccd-4f94-952e-f62988cef786",
+  "name": "My First Project",
+  "type": "DEFAULT",
+  "updated": "2020-12-15T23:45:32.000Z",
+  "updatedBy": {
+    "id": "c8bc0a6a-13bb-49ad-9fcd-60a9a0c4b411",
+    "name": "bar"
+  }
+}
+```
+
+<table class="table table-striped">
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>created</td>
+    <td>date (in ISO-8601 format)</td>
+    <td>Creation date and time of the project.</td>
+  </tr>
+  <tr>
+    <td>createdBy.id</td>
+    <td>string</td>
+    <td>Unique identifier of the user who created the project.</td>
+  </tr>
+  <tr>
+    <td>createdBy.name</td>
+    <td>string</td>
+    <td>Name of the user who created the project.</td>
+  </tr>
+  <tr>
+    <td>id</td>
+    <td>string</td>
+    <td>Unique identifier of the project.</td>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>string</td>
+    <td>Name of the project.</td>
+  </tr>
+  <tr>
+    <td>type</td>
+    <td>number</td>
+    <td>Type of the project.<br/>Possible values: <i>DEFAULT</i>, <i>ENGINE</i>, <i>MODELER</i>, or <i>CATALOG</i>.</td>
+  </tr>
+  <tr>
+    <td>updated</td>
+    <td>date (in ISO-8601 format)</td>
+    <td>Date and time when the project was last updated.</td>
+  </tr>
+  <tr>
+    <td>updatedBy.id</td>
+    <td>string</td>
+    <td>Unique identifier of the user who last updated the project.</td>
+  </tr>
+  <tr>
+    <td>updatedBy.name</td>
+    <td>string</td>
+    <td>Name of the user who last updated the project.</td>
+  </tr>
+</table>
+
+# Methods

--- a/content/reference/rest-api/projects/list.md
+++ b/content/reference/rest-api/projects/list.md
@@ -1,0 +1,29 @@
+---
+title: 'Projects: list'
+weight: 10
+
+menu:
+  main:
+    name: 'list'
+    identifier: 'rest-api-projects-list'
+    parent: 'rest-api-projects'
+    pre: 'Lists projects.'
+---
+
+Lists all projects in the organization.
+
+# Request
+
+## HTTP Request
+
+```
+GET https://cawemo.com/api/v1/projects
+```
+
+## Request Body
+
+Do not supply a request body with this method.
+
+# Response
+
+If successful, this method returns an array of [Project resources]({{< ref "/reference/rest-api/projects/_index.md#resource-representation" >}}) in the response body.

--- a/content/reference/rest-api/templates/_index.md
+++ b/content/reference/rest-api/templates/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Templates'
-weight: 30
+weight: 50
 
 menu:
   main:


### PR DESCRIPTION
Closes https://github.com/camunda/cawemo/issues/11294

Should be backported to all docs later or equal than `1.9`.