### PR TITLE
chore: document endpoints for milestones

### DIFF
--- a/content/reference/rest-api/catalogs/_index.md
+++ b/content/reference/rest-api/catalogs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Catalog Projects'
-weight: 40
+weight: 50
 
 menu:
   main:

--- a/content/reference/rest-api/engine-projects/_index.md
+++ b/content/reference/rest-api/engine-projects/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Engine Projects'
-weight: 60
+weight: 70
 
 menu:
   main:

--- a/content/reference/rest-api/milestones/_index.md
+++ b/content/reference/rest-api/milestones/_index.md
@@ -1,0 +1,86 @@
+---
+title: 'Milestones'
+weight: 40
+
+menu:
+  main:
+    identifier: 'rest-api-milestones'
+    parent: 'rest-api'
+---
+
+See the list of all available [HTTP methods](#methods) for this resource at end of this page.
+
+# Resource Representation
+
+```json
+{
+  "created": "2019-12-15T23:45:32.000Z",
+  "createdBy": {
+    "id": "4975a794-26b0-47a9-b953-a57bb2dc5719",
+    "name": "foo"
+  },
+  "fileId": "c7385b2e-14ac-42b5-98fc-3c960201134c",
+  "id": "def751d7-eccd-4f94-952e-f62988cef786",
+  "name": "My First Milestone",
+  "updated": "2020-12-15T23:45:32.000Z",
+  "updatedBy": {
+    "id": "c8bc0a6a-13bb-49ad-9fcd-60a9a0c4b411",
+    "name": "bar"
+  }
+}
+```
+
+<table class="table table-striped">
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>created</td>
+    <td>date (in ISO-8601 format)</td>
+    <td>Creation date and time of the milestone.</td>
+  </tr>
+  <tr>
+    <td>createdBy.id</td>
+    <td>string</td>
+    <td>Unique identifier of the user who created the milestone.</td>
+  </tr>
+  <tr>
+    <td>createdBy.name</td>
+    <td>string</td>
+    <td>Name of the user who created the milestone.</td>
+  </tr>
+  <tr>
+    <td>fileId</td>
+    <td>string</td>
+    <td>Unique identifier of the parent file.</td>
+  </tr>
+  <tr>
+    <td>id</td>
+    <td>string</td>
+    <td>Unique identifier of the milestone.</td>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>string</td>
+    <td>Name of the milestone.</td>
+  </tr>
+  <tr>
+    <td>updated</td>
+    <td>date (in ISO-8601 format)</td>
+    <td>Date and time when the milestone was last updated.</td>
+  </tr>
+  <tr>
+    <td>updatedBy.id</td>
+    <td>string</td>
+    <td>Unique identifier of the user who last updated the milestone.</td>
+  </tr>
+  <tr>
+    <td>updatedBy.name</td>
+    <td>string</td>
+    <td>Name of the user who last updated the milestone.</td>
+  </tr>
+</table>
+
+# Methods

--- a/content/reference/rest-api/milestones/create.md
+++ b/content/reference/rest-api/milestones/create.md
@@ -1,0 +1,47 @@
+---
+title: 'Milestones: create'
+weight: 10
+
+menu:
+  main:
+    name: 'create'
+    identifier: 'rest-api-milestones-create'
+    parent: 'rest-api-milestones'
+    pre: 'Creates a new milestones.'
+---
+
+Creates a new milestone.
+
+# Request
+
+## HTTP Request
+
+```
+POST https://cawemo.com/api/v1/milestones
+```
+
+## Request Body
+
+In the request body, supply a [Milestones resource]({{< ref "/reference/rest-api/milestones/_index.md#resource-representation" >}}) with the following properties:
+
+<table class="table table-striped">
+  <tr>
+    <th>Property Name</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>fileId</td>
+    <td>string</td>
+    <td>Unique identifier of the file to create the milestone for.</td>
+  </tr>
+  <tr>
+    <td>name</td>
+    <td>string</td>
+    <td>Name of the milestone to create.</td>
+  </tr>
+</table>
+
+# Response
+
+If successful, this method returns a [Milestone resource]({{< ref "/reference/rest-api/milestones/_index.md#resource-representation" >}}) in the response body.

--- a/content/reference/rest-api/milestones/get.md
+++ b/content/reference/rest-api/milestones/get.md
@@ -1,0 +1,62 @@
+---
+title: 'Milestones: get'
+weight: 10
+
+menu:
+  main:
+    name: 'get'
+    identifier: 'rest-api-milestones-get'
+    parent: 'rest-api-milestones'
+    pre: 'Gets a milestone by ID.'
+---
+
+Gets a milestone by ID.
+
+# Request
+
+## HTTP Request
+
+```
+GET https://cawemo.com/api/v1/milestones/:id
+```
+
+## Path Parameters
+
+<table class="table table-striped">
+ <tr>
+   <th>Name</th>
+   <th>Type</th>
+   <th>Description</th>
+ </tr>
+  <tr>
+    <td>id</td>
+    <td>string</td>
+    <td>Unique identifier of the milestone to request.</td>
+  </tr>
+</table>
+
+## Request Body
+
+Do not supply a request body with this method.
+
+# Response
+
+If successful, this method returns the following response body:
+
+<table class="table table-striped">
+  <tr>
+    <th>Name</th>
+    <th>Type</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td>content</td>
+    <td>string</td>
+    <td>Content of the requested milestone.</td>
+  </tr>
+  <tr>
+    <td>metadata</td>
+    <td>object</td>
+    <td>Metadata of the milestone, see <a href="{{< ref "/reference/rest-api/milestones/_index.md#resource-representation" >}}">Milestone resource</a>.</td>
+  </tr>
+</table>

--- a/content/reference/rest-api/milestones/list.md
+++ b/content/reference/rest-api/milestones/list.md
@@ -1,0 +1,44 @@
+---
+title: 'Milestones: list'
+weight: 10
+
+menu:
+  main:
+    name: 'list'
+    identifier: 'rest-api-milestones-list'
+    parent: 'rest-api-milestones'
+    pre: 'Lists milestones.'
+---
+
+Lists all milestones of a file.
+
+# Request
+
+## HTTP Request
+
+```
+GET https://cawemo.com/api/v1/files/:id/milestones
+```
+
+## Path Parameters
+
+<table class="table table-striped">
+ <tr>
+   <th>Name</th>
+   <th>Type</th>
+   <th>Description</th>
+ </tr>
+  <tr>
+    <td>id</td>
+    <td>string</td>
+    <td>Unique identifier of the file of which to list the milestones.</td>
+  </tr>
+</table>
+
+## Request Body
+
+Do not supply a request body with this method.
+
+# Response
+
+If successful, this method returns an array of [Milestone resources]({{< ref "/reference/rest-api/milestones/_index.md#resource-representation" >}}) in the response body.

--- a/content/reference/rest-api/process-definitions/_index.md
+++ b/content/reference/rest-api/process-definitions/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Process Definitions'
-weight: 70
+weight: 80
 
 menu:
   main:

--- a/content/reference/rest-api/templates/_index.md
+++ b/content/reference/rest-api/templates/_index.md
@@ -1,6 +1,6 @@
 ---
 title: 'Templates'
-weight: 50
+weight: 60
 
 menu:
   main:


### PR DESCRIPTION
Closes camunda/cawemo#11561

Should be backported to `latest` and `1.9` with the next Cawemo release.