### PR TITLE
chore: remove enterprise license notices for public API (#229)

### DIFF
--- a/content/reference/rest-api/overview/authentication.md
+++ b/content/reference/rest-api/overview/authentication.md
@@ -8,17 +8,13 @@ menu:
     parent: 'rest-api-overview'
 ---
 
-{{< note title="Heads Up!" class="warning" >}}
-Accessing Cawemo's public API requires a valid Enterprise license.
-{{< /note >}}
-
 Every request to Cawemo's public API requires the use of HTTP Basic Authentication.
 Your request to Cawemo's public API will be successful only if you pass a valid user id and API key combination in the authorization header.
 The user id and API key combination can be retrieved from the settings page of your organization:
 
 {{<img src="../../../../technical-guide/integrations/api-keys.png">}}
 
-To learn more about best practices regarding API keys please visit our [user guide]({{< ref "/user-guide/settings.md#managing-api-keys-enterprise-only" >}}).
+To learn more about best practices regarding API keys please visit our [user guide]({{< ref "/user-guide/settings.md#managing-api-keys" >}}).
 
 Make sure you always Base64-encode your credentials before adding them to the `Authentication: Basic` HTTP header.
 

--- a/content/technical-guide/integrations/engine.md
+++ b/content/technical-guide/integrations/engine.md
@@ -54,7 +54,7 @@ Log in to your target Cawemo instance and create an API key from your organizati
 
 {{<img src="../org-setting.png">}}
 
-To learn more about best practices regarding API keys please visit our [user guide]({{< ref "/user-guide/settings.md#managing-api-keys-enterprise-only" >}}).
+To learn more about best practices regarding API keys please visit our [user guide]({{< ref "/user-guide/settings.md#managing-api-keys" >}}).
 
 ## 2. Extend Your Camunda Process Engine Configuration
 

--- a/content/user-guide/settings.md
+++ b/content/user-guide/settings.md
@@ -15,9 +15,9 @@ This view offers various settings options.
 
 Whether a user wants to receive emails informing about new mentions in [comments](../diagrams#comments) can be adjusted per project.
 
-## Managing API Keys (Enterprise Only)
+## Managing API Keys
 
-With the enterprise license enabled, users can create API Keys that are required to configure [Cawemo's Public API](../../reference/rest-api/) and the [Camunda Platform Engine](../../technical-guide/integrations/engine/) and [Camunda Modeler](../../technical-guide/integrations/modeler/) integrations.
+Users can create API Keys that are required to configure [Cawemo's Public API](../../reference/rest-api/) and the [Camunda Platform Engine](../../technical-guide/integrations/engine/) and [Camunda Modeler](../../technical-guide/integrations/modeler/) integrations.
 
 For use cases located at an organizational level (i.e. Public API and Engine Integration) we recommend creating a separate Cawemo account that owns all API keys.
 


### PR DESCRIPTION
Relates to camunda/cawemo#11598