### PR TITLE
chore: update Camunda engine compatibility matrix

### DIFF
--- a/content/technical-guide/integrations/engine.md
+++ b/content/technical-guide/integrations/engine.md
@@ -191,7 +191,7 @@ For general information about the configuration via Spring XML see the
   <tr>
     <td>1.9</td>
     <td>1.3.x or newer</td>
-    <td>7.17.x or newer</td>
+    <td>7.18.x or newer</td>
   </tr>
   <tr>
     <td>1.8</td>


### PR DESCRIPTION
I think we don't need to mention `7.17.x` any more as it already reached [end of maintenance](https://docs.camunda.org/enterprise/announcement/#camunda-platform-7-17) in October 2023.