### PR TITLE
[Backport 1.9] docs: add retirement callout for engine plugin

### DIFF
--- a/content/technical-guide/integrations/engine.md
+++ b/content/technical-guide/integrations/engine.md
@@ -10,6 +10,11 @@ menu:
     Pre: 'This page describes how you integrate the Camunda Platform Engine with Cawemo.'
 ---
 
+{{< note title="Cawemo Engine Plugin Retirement" class="warning" >}}
+The Cawemo Engine Plugin was retired effective 19th February 2025 and is no longer maintained.
+For more details and alternatives, please refer to [the retirement announcement](https://forum.camunda.io/t/cawemo-enterprise-engine-plugin-retired-alternatives/59789) in the Camunda forum.
+{{< /note >}}
+
 This plugin offers a link between a Camunda Platform Process Engine and a Cawemo instance. It syncs all deployed process definitions to the configured Cawemo account. The synced diagrams will be added to a special project with the name as configured in the plugin.
 
 # Installation

--- a/content/technical-guide/third-party-libraries/engine-plugin-third-party-libraries.md
+++ b/content/technical-guide/third-party-libraries/engine-plugin-third-party-libraries.md
@@ -8,6 +8,11 @@ menu:
     parent: 'third-party-libraries'
 ---
 
+{{< note title="Cawemo Engine Plugin Retirement" class="warning" >}}
+The Cawemo Engine Plugin was retired effective 19th February 2025 and is no longer maintained.
+For more details and alternatives, please refer to [the retirement announcement](https://forum.camunda.io/t/cawemo-enterprise-engine-plugin-retired-alternatives/59789) in the Camunda forum.
+{{< /note >}}
+
 This section covers third-party libraries used by the Camunda Platform Engine Plugin.
 
 * [com.google.code.findbugs:jsr305@3.0.2](http://findbugs.sourceforge.net/), [(The Apache Software License, Version 2.0)](http://www.apache.org/licenses/LICENSE-2.0.txt)


### PR DESCRIPTION
# Description
Backport of #288 to `1.9`.